### PR TITLE
fix Ambiguous occurrence 'defaultTimeLocale'

### DIFF
--- a/Extra/Time.hs
+++ b/Extra/Time.hs
@@ -6,7 +6,7 @@ module Extra.Time
 import Control.Exception
 import Data.List
 import Data.Time
-import System.Locale
+import qualified System.Locale as SL
 import System.Time
 import Text.Printf
 
@@ -53,7 +53,7 @@ myTimeDiffToString diff =
         _ | isPrefixOf "00:" s -> drop 3 s
         _ -> s
     where
-      s = formatTimeDiff defaultTimeLocale "%T" diff
+      s = formatTimeDiff SL.defaultTimeLocale "%T" diff
       ms = ps2ms ps
       ps2ms ps = quot (ps + 500000000) 1000000000
       ps = tdPicosec diff


### PR DESCRIPTION
When I try to install Extra, I get error message as follows. This PR fixes this installation problem.

```
Resolving dependencies...
Configuring Extra-1.46.3...
Building Extra-1.46.3...
Failed to install Extra-1.46.3
Build log ( /Users/kiwamu/.cabal/logs/Extra-1.46.3.log ):
Configuring Extra-1.46.3...
Building Extra-1.46.3...
Preprocessing library Extra-1.46.3...
[ 1 of 20] Compiling Extra.IOThread   ( Extra/IOThread.hs, dist/build/Extra/IOThread.o )
[ 2 of 20] Compiling Test.QuickCheck.Properties ( Test/QuickCheck/Properties.hs, dist/build/Test/QuickCheck/Properties.o )
[ 3 of 20] Compiling Test.QUnit       ( Test/QUnit.hs, dist/build/Test/QUnit.o )

Test/QUnit.hs:62:8: Warning:
    Pattern match(es) are non-exhaustive
    In a case alternative:
        Patterns not matched: QC.InsufficientCoverage _ _ _
[ 4 of 20] Compiling Extra.URI        ( Extra/URI.hs, dist/build/Extra/URI.o )
[ 5 of 20] Compiling Extra.URIQuery   ( Extra/URIQuery.hs, dist/build/Extra/URIQuery.o )
[ 6 of 20] Compiling Extra.Time       ( Extra/Time.hs, dist/build/Extra/Time.o )

Extra/Time.hs:25:35:
    Ambiguous occurrence ‘defaultTimeLocale’
    It could refer to either ‘Data.Time.defaultTimeLocale’,
                             imported from ‘Data.Time’ at Extra/Time.hs:8:1-16
                             (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                          or ‘System.Locale.defaultTimeLocale’,
                             imported from ‘System.Locale’ at Extra/Time.hs:9:1-20

Extra/Time.hs:26:45:
    Ambiguous occurrence ‘defaultTimeLocale’
    It could refer to either ‘Data.Time.defaultTimeLocale’,
                             imported from ‘Data.Time’ at Extra/Time.hs:8:1-16
                             (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                          or ‘System.Locale.defaultTimeLocale’,
                             imported from ‘System.Locale’ at Extra/Time.hs:9:1-20

Extra/Time.hs:27:35:
    Ambiguous occurrence ‘defaultTimeLocale’
    It could refer to either ‘Data.Time.defaultTimeLocale’,
                             imported from ‘Data.Time’ at Extra/Time.hs:8:1-16
                             (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                          or ‘System.Locale.defaultTimeLocale’,
                             imported from ‘System.Locale’ at Extra/Time.hs:9:1-20

Extra/Time.hs:56:26:
    Ambiguous occurrence ‘defaultTimeLocale’
    It could refer to either ‘Data.Time.defaultTimeLocale’,
                             imported from ‘Data.Time’ at Extra/Time.hs:8:1-16
                             (and originally defined in ‘time-1.5.0.1:Data.Time.Format.Locale’)
                          or ‘System.Locale.defaultTimeLocale’,
                             imported from ‘System.Locale’ at Extra/Time.hs:9:1-20
cabal: Error: some packages failed to install:
Extra-1.46.3 failed during the building phase. The exception was:
ExitFailure 1
```

I use ghc 7.10.1 and cabal-install 1.22.2.0 on Mac OSX 10.10.3 with Xcode 6.3.
